### PR TITLE
changed node version from 16 to 16-bullseye in docker file

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16-bullseye
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Stumbled upon this Error when running Docker: https://github.com/parcel-bundler/parcel/issues/6735#issuecomment-1082369506